### PR TITLE
Modify CJI() to accept variables as filter values

### DIFF
--- a/R/idxv.R
+++ b/R/idxv.R
@@ -36,10 +36,12 @@ idxv <- function(DT, Idx, grp = FALSE){
 #' @export
 #' @examples
 #' # see ?idxv examples
-CJI <- function(IDX, ..., nomatch = 0){
+CJI <- function(IDX, values, nomatch = 0){
+  if(!is.list(values)){
+    stop("values argument must be a list()")
+  }
   DT.names <- attr(IDX,"DT.names",TRUE)
   DT.key <- attr(IDX,"DT.key",TRUE)
-  values <- as.list(substitute(list(...)))[-1L]
   idx_skip <- rep(TRUE,length(DT.names))
   idx_skip[0:length(values)] <- sapply(values, isTRUE, USE.NAMES = FALSE)
   args.match <- DT.names[!idx_skip]


### PR DESCRIPTION
CJI() interpreted all filter values literally due to '...' and then as.list(...). Modified it to accept a list of values instead and resolve variables to filter values. As far as I can tell it does not affect performance.
